### PR TITLE
feat: add event emitter for token reporting notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^10.0.0",
+    "@nestjs/event-emitter": "^3.0.1",
     "@nestjs/mongoose": "^11.0.3",
     "@nestjs/platform-express": "^10.0.0",
     "axios": "^1.8.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@nestjs/core':
         specifier: ^10.0.0
         version: 10.4.17(@nestjs/common@10.4.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/event-emitter':
+        specifier: ^3.0.1
+        version: 3.0.1(@nestjs/common@10.4.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.17)
       '@nestjs/mongoose':
         specifier: ^11.0.3
         version: 11.0.3(@nestjs/common@10.4.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.17)(mongoose@8.13.2)(rxjs@7.8.2)
@@ -612,6 +615,12 @@ packages:
         optional: true
       '@nestjs/websockets':
         optional: true
+
+  '@nestjs/event-emitter@3.0.1':
+    resolution: {integrity: sha512-0Ln/x+7xkU6AJFOcQI9tIhUMXVF7D5itiaQGOyJbXtlAfAIt8gzDdJm+Im7cFzKoWkiW5nCXCPh6GSvdQd/3Dw==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
 
   '@nestjs/mongoose@11.0.3':
     resolution: {integrity: sha512-tg7bbKD4MnNMPaiDLXK/JUyTNQxIn3rNnI+oYU1HorLpNiR2E8vPraWVvfptpIj+zferpT6LkrHMvtqvuIKNPw==}
@@ -1578,6 +1587,9 @@ packages:
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
+
+  eventemitter2@6.4.9:
+    resolution: {integrity: sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==}
 
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -3949,6 +3961,12 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@nestjs/event-emitter@3.0.1(@nestjs/common@10.4.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.17)':
+    dependencies:
+      '@nestjs/common': 10.4.17(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.17(@nestjs/common@10.4.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      eventemitter2: 6.4.9
+
   '@nestjs/mongoose@11.0.3(@nestjs/common@10.4.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.17)(mongoose@8.13.2)(rxjs@7.8.2)':
     dependencies:
       '@nestjs/common': 10.4.17(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -5034,6 +5052,8 @@ snapshots:
   etag@1.8.1: {}
 
   event-target-shim@5.0.1: {}
+
+  eventemitter2@6.4.9: {}
 
   events@3.3.0: {}
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AiModule } from './modules/ai/ai.module';
 import { GraphModule } from './modules/graph/graph.module';
+import { NotificationsModule } from './modules/notifications/notifications.module';
 import { RugcheckModule } from './modules/rugcheck/rugcheck.module';
 import { SocialModule } from './modules/social/social.module';
 import { VybeModule } from './modules/vybe/vybe.module';
@@ -23,6 +25,9 @@ import { VybeModule } from './modules/vybe/vybe.module';
       }),
       inject: [ConfigService],
     }),
+    EventEmitterModule.forRoot({
+      delimiter: '.',
+    }),
 
     // Modules
     AiModule,
@@ -30,6 +35,7 @@ import { VybeModule } from './modules/vybe/vybe.module';
     SocialModule,
     GraphModule,
     VybeModule,
+    NotificationsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/modules/notifications/discord-notification.service.ts
+++ b/src/modules/notifications/discord-notification.service.ts
@@ -1,0 +1,78 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { OnEvent } from '@nestjs/event-emitter';
+import { Client, EmbedBuilder } from 'discord.js';
+import { TokenReportEvent } from './payloads/token-report-event.payload';
+
+@Injectable()
+export class DiscordNotificationService {
+  private readonly logger = new Logger(DiscordNotificationService.name);
+  private readonly client: Client;
+
+  constructor(private readonly config: ConfigService) {
+    this.client = new Client({
+      intents: [],
+    });
+
+    const token = this.config.getOrThrow<string>('DISCORD_BOT_TOKEN');
+    this.client.login(token).catch((err) => this.logger.error(err));
+  }
+
+  @OnEvent('token-reported.discord')
+  async handleTokenReported(payload: TokenReportEvent) {
+    try {
+      const { watchers, report, type } = payload;
+
+      const embed = new EmbedBuilder()
+        .setTitle(`🚨 New ${type === 'token' ? 'Token' : 'Creator'} Report`)
+        .setDescription(
+          `A ${type === 'token' ? 'token' : 'creator'} you're watching has been reported for suspicious activity.`,
+        )
+        .addFields(
+          {
+            name: 'Token',
+            value: report.mint,
+            inline: true,
+          },
+          {
+            name: 'Creator',
+            value: report.creator,
+            inline: true,
+          },
+          {
+            name: 'Reason',
+            value: report.message,
+          },
+          {
+            name: 'Timestamp',
+            value: new Date(report.createdAt).toLocaleString(),
+            inline: true,
+          },
+        )
+        .setColor(0xff0000)
+        .setTimestamp();
+
+      if (report.evidence) {
+        embed.addFields({
+          name: 'Evidence',
+          value: `[View Evidence](${report.evidence})`,
+        });
+      }
+
+      // Send notification to each watcher
+      for (const watcher of watchers) {
+        try {
+          const user = await this.client.users.fetch(watcher.userId);
+          await user.send({ embeds: [embed] });
+        } catch (error) {
+          this.logger.error(
+            `Failed to send notification to Discord user ${watcher.userId}`,
+            error,
+          );
+        }
+      }
+    } catch (error) {
+      this.logger.error('Error handling Discord notification', error);
+    }
+  }
+}

--- a/src/modules/notifications/notifications.module.ts
+++ b/src/modules/notifications/notifications.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { DiscordNotificationService } from './discord-notification.service';
+import { TelegramNotificationService } from './telegram-notification.service';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [DiscordNotificationService, TelegramNotificationService],
+})
+export class NotificationsModule {}

--- a/src/modules/notifications/payloads/token-report-event.payload.ts
+++ b/src/modules/notifications/payloads/token-report-event.payload.ts
@@ -1,0 +1,10 @@
+import { TokenReport } from 'src/schemas/token-report.schema';
+import { WatchSubscription } from 'src/schemas/watch-subscription.schema';
+
+export class TokenReportEvent {
+  constructor(
+    public readonly watchers: WatchSubscription[],
+    public readonly report: TokenReport,
+    public readonly type: 'token' | 'creator',
+  ) {}
+}

--- a/src/modules/notifications/telegram-notification.service.ts
+++ b/src/modules/notifications/telegram-notification.service.ts
@@ -1,0 +1,62 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { OnEvent } from '@nestjs/event-emitter';
+import { escapeMarkdown } from 'src/shared/utils';
+import { Telegraf } from 'telegraf';
+import { TokenReportEvent } from './payloads/token-report-event.payload';
+
+@Injectable()
+export class TelegramNotificationService {
+  private readonly logger = new Logger(TelegramNotificationService.name);
+  private readonly bot: Telegraf;
+
+  constructor(private readonly config: ConfigService) {
+    const token = this.config.getOrThrow<string>('TELEGRAM_BOT_TOKEN');
+    this.bot = new Telegraf(token);
+  }
+
+  @OnEvent('token-reported.telegram')
+  async handleTokenReported(payload: TokenReportEvent) {
+    try {
+      const { watchers, report, type } = payload;
+
+      const message = [
+        `*🚨 New ${type === 'token' ? 'Token' : 'Creator'} Report*`,
+        '',
+        `A ${type === 'token' ? 'token' : 'creator'} you're watching has been reported for suspicious activity\\.`,
+        '',
+        `*Token:* \`${escapeMarkdown(report.mint)}\``,
+        `*Creator:* \`${escapeMarkdown(report.creator)}\``,
+        `*Reason:* ${escapeMarkdown(report.message)}`,
+        `*Timestamp:* ${new Date(report.createdAt).toLocaleString()}`,
+      ];
+
+      if (report.evidence) {
+        message.push(
+          '',
+          `*Evidence:* [View](${escapeMarkdown(report.evidence)})`,
+        );
+      }
+
+      // Send notification to each watcher
+      for (const watcher of watchers) {
+        try {
+          await this.bot.telegram.sendMessage(
+            watcher.userId,
+            message.join('\n'),
+            {
+              parse_mode: 'MarkdownV2',
+            },
+          );
+        } catch (error) {
+          this.logger.error(
+            `Failed to send notification to Telegram user ${watcher.userId}`,
+            error,
+          );
+        }
+      }
+    } catch (error) {
+      this.logger.error('Error handling Telegram notification', error);
+    }
+  }
+}

--- a/src/modules/report/report.service.ts
+++ b/src/modules/report/report.service.ts
@@ -1,0 +1,164 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import {
+  CreatorReport,
+  TokenReportResponse,
+  TokenReportStats,
+} from 'src/common/interfaces/rugcheck';
+import { TokenReport } from 'src/schemas/token-report.schema';
+import { WatchSubscription } from 'src/schemas/watch-subscription.schema';
+import { TokenReportEvent } from '../notifications/payloads/token-report-event.payload';
+import { WatchService } from '../watch/watch.service';
+
+@Injectable()
+export class ReportService {
+  private readonly logger = new Logger(ReportService.name);
+
+  constructor(
+    @InjectModel(TokenReport.name)
+    private tokenReportModel: Model<TokenReport>,
+    private readonly watchService: WatchService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async reportToken(
+    mint: string,
+    reportData: {
+      creator: string;
+      reportedBy: string;
+      platform: string;
+      message: string;
+      evidence?: string;
+    },
+  ): Promise<TokenReportResponse> {
+    try {
+      const existingReport = await this.tokenReportModel.findOne({
+        mint,
+        reportedBy: reportData.reportedBy,
+      });
+
+      if (existingReport) {
+        return {
+          success: false,
+          message: 'You have already reported this token.',
+        };
+      }
+
+      const report = new this.tokenReportModel({
+        mint,
+        ...reportData,
+      });
+      await report.save();
+
+      // Notify watchers after successful report
+      await this.notifyWatchers(report);
+
+      return {
+        success: true,
+        message: 'Token has been reported successfully.',
+      };
+    } catch (error) {
+      this.logger.error('Failed to save token report', error);
+      return {
+        success: false,
+        message: 'Failed to save report.',
+      };
+    }
+  }
+
+  async getTokenReportStats(mint: string): Promise<TokenReportStats> {
+    const reports = await this.tokenReportModel
+      .find({ mint })
+      .sort({ createdAt: -1 })
+      .exec();
+
+    const creator = reports[0]?.creator;
+    const creatorReports = creator
+      ? (await this.tokenReportModel.find({ creator }).exec()).length
+      : 0;
+
+    return {
+      tokenReports: reports.length,
+      creatorReports,
+      reports,
+    };
+  }
+
+  async getCreatorReport(creator: string): Promise<CreatorReport> {
+    try {
+      const reports = await this.tokenReportModel
+        .find({ creator })
+        .sort({ createdAt: -1 })
+        .exec();
+
+      return {
+        reports,
+        totalReports: reports.length,
+        uniqueTokensReported: new Set(reports.map((r) => r.mint)).size,
+      };
+    } catch (error) {
+      this.logger.error('Failed to fetch creator reports', error);
+      throw error;
+    }
+  }
+
+  private async notifyWatchers(report: TokenReport): Promise<void> {
+    try {
+      const tokenWatchers = await this.watchService.getWatchersForItem({
+        token: report.mint,
+      });
+      const creatorWatchers = await this.watchService.getWatchersForItem({
+        creator: report.creator,
+      });
+
+      // Group watchers by platform for efficient notification
+      const tokenWatchersByPlatform = tokenWatchers.reduce((acc, watcher) => {
+        if (!acc[watcher.platform]) {
+          acc[watcher.platform] = [];
+        }
+        acc[watcher.platform].push(watcher);
+        return acc;
+      }, {});
+      const creatorWatchersByPlatform = creatorWatchers.reduce(
+        (acc, watcher) => {
+          if (!acc[watcher.platform]) {
+            acc[watcher.platform] = [];
+          }
+          acc[watcher.platform].push(watcher);
+          return acc;
+        },
+        {},
+      );
+
+      // Emit events for each platform to handle notifications
+      Object.entries(tokenWatchersByPlatform).forEach(
+        ([platform, platformWatchers]) => {
+          this.eventEmitter.emit(
+            `token-reported.${platform}`,
+            new TokenReportEvent(
+              platformWatchers as WatchSubscription[],
+              report,
+              'token',
+            ),
+          );
+        },
+      );
+      Object.entries(creatorWatchersByPlatform).forEach(
+        ([platform, platformWatchers]) => {
+          this.eventEmitter.emit(
+            `token-reported.${platform}`,
+            new TokenReportEvent(
+              platformWatchers as WatchSubscription[],
+              report,
+              'creator',
+            ),
+          );
+        },
+      );
+    } catch (error) {
+      this.logger.error('Failed to notify watchers', error);
+    }
+  }
+}

--- a/src/modules/rugcheck/rugcheck.module.ts
+++ b/src/modules/rugcheck/rugcheck.module.ts
@@ -5,6 +5,12 @@ import {
   TokenReport,
   TokenReportSchema,
 } from '../../schemas/token-report.schema';
+import {
+  WatchSubscription,
+  WatchSubscriptionSchema,
+} from '../../schemas/watch-subscription.schema';
+import { ReportService } from '../report/report.service';
+import { WatchService } from '../watch/watch.service';
 import { RugcheckService } from './rugcheck.service';
 
 @Module({
@@ -12,9 +18,10 @@ import { RugcheckService } from './rugcheck.service';
     HttpModule,
     MongooseModule.forFeature([
       { name: TokenReport.name, schema: TokenReportSchema },
+      { name: WatchSubscription.name, schema: WatchSubscriptionSchema },
     ]),
   ],
-  providers: [RugcheckService],
-  exports: [RugcheckService],
+  providers: [RugcheckService, WatchService, ReportService],
+  exports: [RugcheckService, WatchService, ReportService],
 })
 export class RugcheckModule {}

--- a/src/modules/rugcheck/rugcheck.service.ts
+++ b/src/modules/rugcheck/rugcheck.service.ts
@@ -1,22 +1,17 @@
 import { HttpService } from '@nestjs/axios';
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { InjectModel } from '@nestjs/mongoose';
 import { AxiosError } from 'axios';
-import { Model } from 'mongoose';
 import { lastValueFrom } from 'rxjs';
 import {
-  CreatorReport,
   InsidersGraphData,
   RecentToken,
   RugCheckTokenReport,
-  TokenReportResponse,
-  TokenReportStats,
   TokenStat,
   TrendingToken,
   VerifiedToken,
 } from 'src/common/interfaces/rugcheck';
-import { TokenReport } from 'src/schemas/token-report.schema';
+import { ReportService } from '../report/report.service';
 
 @Injectable()
 export class RugcheckService {
@@ -26,21 +21,21 @@ export class RugcheckService {
 
   constructor(
     private readonly httpService: HttpService,
+    private readonly reportService: ReportService,
     private readonly config: ConfigService,
-    @InjectModel(TokenReport.name)
-    private tokenReportModel: Model<TokenReport>,
   ) {
     this.baseUrl = this.config.getOrThrow<string>('RUGCHECK_API_URL');
     this.apiKey = this.config.getOrThrow<string>('RUGCHECK_API_KEY');
   }
 
+  // Keep only API-related methods
   async getTokenReport(
     mintAddress: string,
   ): Promise<RugCheckTokenReport | string> {
     try {
       const [apiReport, communityReports] = await Promise.all([
         this.fetchTokenReport(mintAddress),
-        this.getTokenReportStats(mintAddress),
+        this.reportService.getTokenReportStats(mintAddress),
       ]);
 
       return typeof apiReport === 'string'
@@ -92,84 +87,6 @@ export class RugcheckService {
 
       this.logger.error(`RugCheck API error: ${error.message}`);
       return 'An error occurred while fetching the token report.';
-    }
-  }
-
-  async reportToken(
-    mint: string,
-    reportData: {
-      creator: string;
-      reportedBy: string;
-      platform: string;
-      message: string;
-      evidence?: string;
-    },
-  ): Promise<TokenReportResponse> {
-    try {
-      // Check if user has reported this token before
-      const existingReport = await this.tokenReportModel.findOne({
-        mint,
-        reportedBy: reportData.reportedBy,
-      });
-      if (existingReport) {
-        return {
-          success: false,
-          message: 'You have already reported this token.',
-        };
-      }
-
-      const report = new this.tokenReportModel({
-        mint,
-        ...reportData,
-      });
-      await report.save();
-
-      return {
-        success: true,
-        message: 'Token has been reported successfully.',
-      };
-    } catch (error) {
-      this.logger.error('Failed to save token report', error);
-      return {
-        success: false,
-        message: 'Failed to save report.',
-      };
-    }
-  }
-
-  async getTokenReportStats(mint: string): Promise<TokenReportStats> {
-    const reports = await this.tokenReportModel
-      .find({ mint })
-      .sort({ createdAt: -1 })
-      .exec();
-    const creator = reports[0]?.creator;
-
-    const creatorReports = creator
-      ? (await this.tokenReportModel.find({ creator }).exec()).length
-      : 0;
-
-    return {
-      tokenReports: reports.length,
-      creatorReports,
-      reports,
-    };
-  }
-
-  async getCreatorReport(creator: string): Promise<CreatorReport> {
-    try {
-      const reports = await this.tokenReportModel
-        .find({ creator })
-        .sort({ createdAt: -1 })
-        .exec();
-
-      return {
-        reports,
-        totalReports: reports.length,
-        uniqueTokensReported: new Set(reports.map((r) => r.mint)).size,
-      };
-    } catch (error) {
-      this.logger.error('Failed to fetch creator reports', error);
-      throw error;
     }
   }
 

--- a/src/modules/social/base/base.commands.ts
+++ b/src/modules/social/base/base.commands.ts
@@ -12,4 +12,9 @@ export abstract class BaseCommands {
   abstract handleVerifiedCommand(...args: any[]): Promise<any>;
   abstract handleCreatorCommand(...args: any[]): Promise<any>;
   abstract handleInsidersCommand(...args: any[]): Promise<any>;
+  abstract handleAnalyzeNetworkCommand(...args: any[]): Promise<any>;
+  abstract handleWatchCreatorCommand(...args: any[]): Promise<any>;
+  abstract handleUnwatchCreatorCommand(...args: any[]): Promise<any>;
+  abstract handleWatchTokenCommand(...args: any[]): Promise<any>;
+  abstract handleUnwatchTokenCommand(...args: any[]): Promise<any>;
 }

--- a/src/modules/social/discord/discord.service.ts
+++ b/src/modules/social/discord/discord.service.ts
@@ -2,7 +2,9 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Client, IntentsBitField, Message } from 'discord.js';
 import { GraphService } from 'src/modules/graph/graph.service';
+import { ReportService } from 'src/modules/report/report.service';
 import { VybeService } from 'src/modules/vybe/vybe.service';
+import { WatchService } from 'src/modules/watch/watch.service';
 import { AiService } from '../../ai/ai.service';
 import { RugcheckService } from '../../rugcheck/rugcheck.service';
 import { BasePlatformService } from '../base/base.service';
@@ -20,7 +22,9 @@ export class DiscordService extends BasePlatformService {
     private readonly aiService: AiService,
     private readonly rugcheckService: RugcheckService,
     private readonly graphService: GraphService,
-    private readonly birdeyeService: VybeService,
+    private readonly vybeService: VybeService,
+    private readonly watchService: WatchService,
+    private readonly reportService: ReportService,
   ) {
     super();
     this.client = new Client({
@@ -34,11 +38,14 @@ export class DiscordService extends BasePlatformService {
       this.aiService,
       this.rugcheckService,
       this.graphService,
-      this.birdeyeService,
+      this.vybeService,
+      this.watchService,
+      this.reportService,
     );
     this.interactions = new DiscordInteractions(
       this.aiService,
       this.rugcheckService,
+      this.reportService,
     );
 
     this.client.on('messageCreate', async (message) => {
@@ -56,6 +63,10 @@ export class DiscordService extends BasePlatformService {
         '!insiders': this.commands.handleInsidersCommand.bind(this),
         '!analyze_network':
           this.commands.handleAnalyzeNetworkCommand.bind(this),
+        '!wc': this.commands.handleWatchCreatorCommand.bind(this),
+        '!uc': this.commands.handleUnwatchCreatorCommand.bind(this),
+        '!wt': this.commands.handleWatchTokenCommand.bind(this),
+        '!ut': this.commands.handleUnwatchTokenCommand.bind(this),
       };
 
       const command = message.content.split(' ')[0].toLowerCase();
@@ -127,6 +138,18 @@ export class DiscordService extends BasePlatformService {
         break;
       case '!analyze_network':
         await this.commands.handleAnalyzeNetworkCommand(msg);
+        break;
+      case '!wc':
+        await this.commands.handleWatchCreatorCommand(msg);
+        break;
+      case '!uc':
+        await this.commands.handleUnwatchCreatorCommand(msg);
+        break;
+      case '!wt':
+        await this.commands.handleWatchTokenCommand(msg);
+        break;
+      case '!ut':
+        await this.commands.handleUnwatchTokenCommand(msg);
         break;
       default:
         this.logger.log(`Unknown command: ${command}`);

--- a/src/modules/social/discord/interactions/discord.interactions.ts
+++ b/src/modules/social/discord/interactions/discord.interactions.ts
@@ -10,6 +10,7 @@ import {
   TextInputStyle,
 } from 'discord.js';
 import { AiService } from 'src/modules/ai/ai.service';
+import { ReportService } from 'src/modules/report/report.service';
 import { RugcheckService } from 'src/modules/rugcheck/rugcheck.service';
 import {
   formatCreatorReport,
@@ -22,6 +23,7 @@ export class DiscordInteractions {
   constructor(
     private readonly aiService: AiService,
     private readonly rugcheckService: RugcheckService,
+    private readonly reportService: ReportService,
   ) {}
 
   async handleReportButton(interaction: ButtonInteraction) {
@@ -111,7 +113,7 @@ export class DiscordInteractions {
         return interaction.editReply(tokenInfo);
       }
 
-      const result = await this.rugcheckService.reportToken(mintAddress, {
+      const result = await this.reportService.reportToken(mintAddress, {
         creator: tokenInfo.creator,
         reportedBy: interaction.user.id,
         platform: 'discord',
@@ -149,7 +151,7 @@ export class DiscordInteractions {
       }
 
       await interaction.deferReply();
-      const report = await this.rugcheckService.getCreatorReport(address);
+      const report = await this.reportService.getCreatorReport(address);
       const { embed } = formatCreatorReport(address, report);
 
       await interaction.editReply({ embeds: [embed] });

--- a/src/modules/social/telegram/telegram.service.ts
+++ b/src/modules/social/telegram/telegram.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, OnModuleDestroy } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { ReportService } from 'src/modules/report/report.service';
 import { VybeService } from 'src/modules/vybe/vybe.service';
+import { WatchService } from 'src/modules/watch/watch.service';
 import { Context, Telegraf } from 'telegraf';
 import { AiService } from '../../ai/ai.service';
 import { GraphService } from '../../graph/graph.service';
@@ -20,8 +22,10 @@ export class TelegramService
     private readonly config: ConfigService,
     private readonly aiService: AiService,
     private readonly rugcheckService: RugcheckService,
-    private readonly birdeyeService: VybeService,
+    private readonly vybeService: VybeService,
     private readonly graphService: GraphService,
+    private readonly watchService: WatchService,
+    private readonly reportService: ReportService,
   ) {
     super();
 
@@ -45,8 +49,10 @@ export class TelegramService
       this.config,
       this.aiService,
       this.rugcheckService,
-      this.birdeyeService,
+      this.vybeService,
       this.graphService,
+      this.watchService,
+      this.reportService,
     );
 
     this.bot.command('help', (ctx) => this.commands.handleHelpCommand(ctx));
@@ -86,6 +92,17 @@ export class TelegramService
     );
     this.bot.command('analyze_network', (ctx) =>
       this.commands.handleAnalyzeNetworkCommand(ctx),
+    );
+
+    this.bot.command('wc', (ctx) =>
+      this.commands.handleWatchCreatorCommand(ctx),
+    );
+    this.bot.command('uc', (ctx) =>
+      this.commands.handleUnwatchCreatorCommand(ctx),
+    );
+    this.bot.command('wt', (ctx) => this.commands.handleWatchTokenCommand(ctx));
+    this.bot.command('ut', (ctx) =>
+      this.commands.handleUnwatchTokenCommand(ctx),
     );
 
     // Add photo message handler

--- a/src/modules/watch/watch.service.ts
+++ b/src/modules/watch/watch.service.ts
@@ -1,0 +1,138 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { WatchSubscription } from 'src/schemas/watch-subscription.schema';
+
+@Injectable()
+export class WatchService {
+  private readonly logger = new Logger(WatchService.name);
+
+  constructor(
+    @InjectModel(WatchSubscription.name)
+    private watchSubscriptionModel: Model<WatchSubscription>,
+  ) {}
+
+  async watchAddress(
+    userId: string,
+    platform: string,
+    address: string,
+  ): Promise<string> {
+    try {
+      const existing = await this.watchSubscriptionModel.findOne({
+        userId,
+        platform,
+        watchedAddress: address,
+      });
+
+      if (existing) {
+        return 'You are already watching this address.';
+      }
+
+      const subscription = new this.watchSubscriptionModel({
+        userId,
+        platform,
+        watchedAddress: address,
+      });
+      await subscription.save();
+
+      return 'Successfully started watching this address.';
+    } catch (error) {
+      this.logger.error('Failed to watch address', error);
+      throw error;
+    }
+  }
+
+  async unwatchAddress(
+    userId: string,
+    platform: string,
+    address: string,
+  ): Promise<string> {
+    try {
+      const result = await this.watchSubscriptionModel.deleteOne({
+        userId,
+        platform,
+        watchedAddress: address,
+      });
+
+      return result.deletedCount > 0
+        ? 'Successfully stopped watching this address.'
+        : 'You were not watching this address.';
+    } catch (error) {
+      this.logger.error('Failed to unwatch address', error);
+      throw error;
+    }
+  }
+
+  async watchToken(
+    userId: string,
+    platform: string,
+    token: string,
+  ): Promise<string> {
+    try {
+      const existing = await this.watchSubscriptionModel.findOne({
+        userId,
+        platform,
+        watchedToken: token,
+      });
+
+      if (existing) {
+        return 'You are already watching this token.';
+      }
+
+      const subscription = new this.watchSubscriptionModel({
+        userId,
+        platform,
+        watchedToken: token,
+      });
+      await subscription.save();
+
+      return 'Successfully started watching this token.';
+    } catch (error) {
+      this.logger.error('Failed to watch token', error);
+      throw error;
+    }
+  }
+
+  async unwatchToken(
+    userId: string,
+    platform: string,
+    token: string,
+  ): Promise<string> {
+    try {
+      const result = await this.watchSubscriptionModel.deleteOne({
+        userId,
+        platform,
+        watchedToken: token,
+      });
+
+      return result.deletedCount > 0
+        ? 'Successfully stopped watching this token.'
+        : 'You were not watching this token.';
+    } catch (error) {
+      this.logger.error('Failed to unwatch token', error);
+      throw error;
+    }
+  }
+
+  async getWatchersForItem(params: {
+    token?: string;
+    creator?: string;
+  }): Promise<WatchSubscription[]> {
+    try {
+      if (!params.token && !params.creator) {
+        throw new Error('Either token or creator must be provided.');
+      }
+
+      return await this.watchSubscriptionModel
+        .find(
+          params.token
+            ? { watchedToken: params.token }
+            : { watchedAddress: params.creator },
+        )
+        .exec();
+    } catch (error) {
+      this.logger.error('Failed to get watchers', error);
+      throw error;
+    }
+  }
+}

--- a/src/schemas/watch-subscription.schema.ts
+++ b/src/schemas/watch-subscription.schema.ts
@@ -1,0 +1,28 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema({ timestamps: true })
+export class WatchSubscription extends Document {
+  @Prop({ required: true })
+  userId: string;
+
+  @Prop({ required: true })
+  platform: string;
+
+  @Prop()
+  watchedAddress?: string;
+
+  @Prop()
+  watchedToken?: string;
+
+  @Prop({ default: new Date() })
+  createdAt: Date;
+}
+
+export const WatchSubscriptionSchema =
+  SchemaFactory.createForClass(WatchSubscription);
+
+// Add indexes for better query performance
+WatchSubscriptionSchema.index({ userId: 1, platform: 1 });
+WatchSubscriptionSchema.index({ watchedAddress: 1 });
+WatchSubscriptionSchema.index({ watchedToken: 1 });


### PR DESCRIPTION
- Added @nestjs/event-emitter to handle event-driven notifications for token reports.
- Created DiscordNotificationService to send notifications to Discord users when a token is reported.
- Implemented TelegramNotificationService for sending notifications to Telegram users.
- Introduced WatchService to manage user subscriptions for watching tokens and creators.
- Updated ReportService to emit events for notifying watchers after a token report is created.
- Added commands in Discord and Telegram to allow users to watch/unwatch tokens and creators.
- Created WatchSubscription schema to store user subscriptions for tokens and creators.